### PR TITLE
feat(updates.jenkins.io): add `westeurope.cloudflare.jenkins.io` zone

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   default_tags = {
     scope      = "terraform-managed"
-    repository = "jenkins-infra/azure"
+    repository = "jenkins-infra/cloudflare"
   }
 
   account_id = {

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,5 @@
 locals {
-  default_tags = {
-    scope      = "terraform-managed"
-    repository = "jenkins-infra/cloudflare"
-  }
+  default_tags = ["scope: terraform-managed", "repository: jenkins-infra/cloudflare"]
 
   account_id = {
     jenkins-infra-team = "8d1838a43923148c5cee18ccc356a594"

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,9 @@
 locals {
+  default_tags = {
+    scope      = "terraform-managed"
+    repository = "jenkins-infra/azure"
+  }
+
   account_id = {
     jenkins-infra-team = "8d1838a43923148c5cee18ccc356a594"
   }

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -3,3 +3,28 @@ resource "cloudflare_r2_bucket" "westeurope_updates_jenkins_io" {
   name       = "westeurope-updates-jenkins-io"
   location   = "WEUR"
 }
+
+# Keeping this main zone imported as data only so we don't risk destroying it (the sponsoring is attached to it)
+data "cloudflare_zone" "cloudflare_jenkins_io" {
+  account_id = local.account_id["jenkins-infra-team"]
+  name       = "cloudflare.jenkins.io"
+}
+
+## West Europe
+resource "cloudflare_record" "westeurope" {
+  for_each = data.cloudflare_zone.cloudflare_jenkins_io.name_servers
+
+  zone_id = data.cloudflare_zone.cloudflare_jenkins_io.id
+  name    = "westeurope"
+  value   = "${each.key}"
+  type    = "NS"
+  ttl     = 60
+}
+
+resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
+  account_id = local.account_id["jenkins-infra-team"]
+  zone       = "westeurope.cloudflare.jenkins.io"
+  depends_on = [
+    cloudflare_record.westeurope
+  ]
+}

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -11,7 +11,7 @@ resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
 }
 
 resource "cloudflare_record" "ns_westeurope" {
-  count = length(data.cloudflare_jenkins_io.name_servers)
+  count = length(data.cloudflare_zone.cloudflare_jenkins_io.name_servers)
 
   zone_id = data.cloudflare_zone.cloudflare_jenkins_io.id
   name    = "westeurope"

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -1,9 +1,3 @@
-resource "cloudflare_r2_bucket" "westeurope_updates_jenkins_io" {
-  account_id = local.account_id["jenkins-infra-team"]
-  name       = "westeurope-updates-jenkins-io"
-  location   = "WEUR"
-}
-
 # Keeping this main zone imported as data only so we don't risk destroying it (the sponsoring is attached to it)
 data "cloudflare_zone" "cloudflare_jenkins_io" {
   account_id = local.account_id["jenkins-infra-team"]
@@ -11,8 +5,13 @@ data "cloudflare_zone" "cloudflare_jenkins_io" {
 }
 
 ## West Europe
-resource "cloudflare_record" "westeurope" {
-  for_each = toset(data.cloudflare_zone.cloudflare_jenkins_io.name_servers)
+resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
+  account_id = local.account_id["jenkins-infra-team"]
+  zone       = "westeurope.cloudflare.jenkins.io"
+}
+
+resource "cloudflare_record" "ns_westeurope" {
+  for_each = toset(cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers)
 
   zone_id = data.cloudflare_zone.cloudflare_jenkins_io.id
   name    = "westeurope"
@@ -21,10 +20,8 @@ resource "cloudflare_record" "westeurope" {
   ttl     = 60
 }
 
-resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
+resource "cloudflare_r2_bucket" "westeurope_updates_jenkins_io" {
   account_id = local.account_id["jenkins-infra-team"]
-  zone       = "westeurope.cloudflare.jenkins.io"
-  depends_on = [
-    cloudflare_record.westeurope
-  ]
+  name       = "westeurope-updates-jenkins-io"
+  location   = "WEUR"
 }

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -12,7 +12,7 @@ data "cloudflare_zone" "cloudflare_jenkins_io" {
 
 ## West Europe
 resource "cloudflare_record" "westeurope" {
-  for_each = data.cloudflare_zone.cloudflare_jenkins_io.name_servers
+  for_each = toset(data.cloudflare_zone.cloudflare_jenkins_io.name_servers)
 
   zone_id = data.cloudflare_zone.cloudflare_jenkins_io.id
   name    = "westeurope"

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -11,7 +11,7 @@ resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
 }
 
 resource "cloudflare_record" "ns_westeurope" {
-  count = length(data.cloudflare_zone.cloudflare_jenkins_io.name_servers)
+  count = 2
 
   zone_id = data.cloudflare_zone.cloudflare_jenkins_io.id
   name    = "westeurope"

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -11,12 +11,10 @@ resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
 }
 
 resource "cloudflare_record" "ns_westeurope" {
-  count = 2
-  # for_each = toset(cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers)
+  count = length(data.cloudflare_jenkins_io.name_servers)
 
   zone_id = data.cloudflare_zone.cloudflare_jenkins_io.id
   name    = "westeurope"
-  # value   = "${each.key}"
   value   = cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers[count.index]
   type    = "NS"
   ttl     = 60

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -11,7 +11,7 @@ resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
 }
 
 resource "cloudflare_record" "ns_westeurope" {
-  count = length(data.cloudflare_zone.cloudflare_jenkins_io.name_servers)
+  count = length(cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers)
 
   zone_id = data.cloudflare_zone.cloudflare_jenkins_io.id
   name    = "westeurope"

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -19,7 +19,7 @@ resource "cloudflare_record" "ns_westeurope" {
   type    = "NS"
   ttl     = 60
 
-  tags = [for key, value in local.default_tags : "${key}:${value}"]
+  tags = local.default_tags
 }
 
 resource "cloudflare_r2_bucket" "westeurope_updates_jenkins_io" {

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -11,7 +11,7 @@ resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
 }
 
 resource "cloudflare_record" "ns_westeurope" {
-  count = length(cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers)
+  count = length(data.cloudflare_zone.cloudflare_jenkins_io.name_servers)
 
   zone_id = data.cloudflare_zone.cloudflare_jenkins_io.id
   name    = "westeurope"

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -19,7 +19,7 @@ resource "cloudflare_record" "ns_westeurope" {
   type    = "NS"
   ttl     = 60
 
-  tags = local.default_tags
+  tags = [for key, value in local.default_tags : "${key}:${value}"]
 }
 
 resource "cloudflare_r2_bucket" "westeurope_updates_jenkins_io" {

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -11,11 +11,13 @@ resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
 }
 
 resource "cloudflare_record" "ns_westeurope" {
-  for_each = toset(cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers)
+  count = 2
+  # for_each = toset(cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers)
 
   zone_id = data.cloudflare_zone.cloudflare_jenkins_io.id
   name    = "westeurope"
-  value   = "${each.key}"
+  # value   = "${each.key}"
+  value   = cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers[count.index]
   type    = "NS"
   ttl     = 60
 }

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -18,6 +18,8 @@ resource "cloudflare_record" "ns_westeurope" {
   value   = cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers[count.index]
   type    = "NS"
   ttl     = 60
+
+  tags = local.default_tags
 }
 
 resource "cloudflare_r2_bucket" "westeurope_updates_jenkins_io" {


### PR DESCRIPTION
This PR create the `westeurope.cloudflare.jenkins.io` zone which will be used as custom public domain for the corresponding R2 bucket already defined here: https://github.com/jenkins-infra/cloudflare/blob/688cfff72c164948207f83151ee4cd0338a1f1b0/updates.jenkins.io.tf#L1-L5

Note: this custom domain link will be made later via CloudFlare admin, not possible neither from the terraform provider neither the API at the moment, cf https://github.com/cloudflare/terraform-provider-cloudflare/issues/2537

Ref: https://github.com/jenkins-infra/helpdesk/issues/2649