### PR TITLE
chore(updates.jenkins.io): remove NS records and `cloudflare.jenkins.io` data resource

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,4 @@
 locals {
-  default_tags = ["scope: terraform-managed", "repository: jenkins-infra/cloudflare"]
-
   account_id = {
     jenkins-infra-team = "8d1838a43923148c5cee18ccc356a594"
   }

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -1,29 +1,15 @@
-# Keeping this main zone imported as data only so we don't risk destroying it (the sponsoring is attached to it)
-data "cloudflare_zone" "cloudflare_jenkins_io" {
-  account_id = local.account_id["jenkins-infra-team"]
-  name       = "cloudflare.jenkins.io"
-}
-
-## West Europe
+# West Europe
 resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
   account_id = local.account_id["jenkins-infra-team"]
   zone       = "westeurope.cloudflare.jenkins.io"
-}
-
-resource "cloudflare_record" "ns_westeurope" {
-  count = 2
-
-  zone_id = data.cloudflare_zone.cloudflare_jenkins_io.id
-  name    = "westeurope"
-  value   = cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers[count.index]
-  type    = "NS"
-  ttl     = 60
-
-  tags = local.default_tags
 }
 
 resource "cloudflare_r2_bucket" "westeurope_updates_jenkins_io" {
   account_id = local.account_id["jenkins-infra-team"]
   name       = "westeurope-updates-jenkins-io"
   location   = "WEUR"
+}
+
+output "westeurope_cloudflare_jenkins_io_ns_records" {
+  value = cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers
 }


### PR DESCRIPTION
This PR removes the NS records associated to `westeurope.cloudflare.jenkins.io` from CloudFlare, to be declared in Azure.

It also remove the data resource corresponding to `cloudflare.jenkins.io` zone, removed from CloudFlare so it won't interact with the other zones, preventing TLS to be set.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2649