### PR TITLE
chore(updates.jenkins.io): comment out `westeurope` zone to recreate it later

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -1,8 +1,8 @@
 # West Europe
-resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
-  account_id = local.account_id["jenkins-infra-team"]
-  zone       = "westeurope.cloudflare.jenkins.io"
-}
+# resource "cloudflare_zone" "westeurope_cloudflare_jenkins_io" {
+#   account_id = local.account_id["jenkins-infra-team"]
+#   zone       = "westeurope.cloudflare.jenkins.io"
+# }
 
 resource "cloudflare_r2_bucket" "westeurope_updates_jenkins_io" {
   account_id = local.account_id["jenkins-infra-team"]
@@ -10,6 +10,6 @@ resource "cloudflare_r2_bucket" "westeurope_updates_jenkins_io" {
   location   = "WEUR"
 }
 
-output "westeurope_cloudflare_jenkins_io_ns_records" {
-  value = cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers
-}
+# output "westeurope_cloudflare_jenkins_io_ns_records" {
+#   value = cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers
+# }


### PR DESCRIPTION
As this zone SSL edge certificate seems stuck in "pending validation", this PR comments it out so it can be recreated later.

![image](https://github.com/jenkins-infra/cloudflare/assets/91831478/56bd2d7c-a3c4-479d-aaec-97f5dc073b87)
