### PR TITLE
chore(updates.jenkins.io): comment out R2 bucket too

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -4,11 +4,11 @@
 #   zone       = "westeurope.cloudflare.jenkins.io"
 # }
 
-resource "cloudflare_r2_bucket" "westeurope_updates_jenkins_io" {
-  account_id = local.account_id["jenkins-infra-team"]
-  name       = "westeurope-updates-jenkins-io"
-  location   = "WEUR"
-}
+# resource "cloudflare_r2_bucket" "westeurope_updates_jenkins_io" {
+#   account_id = local.account_id["jenkins-infra-team"]
+#   name       = "westeurope-updates-jenkins-io"
+#   location   = "WEUR"
+# }
 
 # output "westeurope_cloudflare_jenkins_io_ns_records" {
 #   value = cloudflare_zone.westeurope_cloudflare_jenkins_io.name_servers


### PR DESCRIPTION
Similar to #11, 

![image](https://github.com/jenkins-infra/cloudflare/assets/91831478/969acf20-8b60-4840-9546-febc05ef59f0)
