### PR TITLE
chore: bump Terraform to 1.9.x

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -4,7 +4,7 @@ locals {
   }
 
   regions = {
-    westeurope = "WEUR"
+    westeurope  = "WEUR"
     eastamerica = "ENAM"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6, <1.7"
+  required_version = ">= 1.9, <1.10"
   required_providers {
     cloudflare = {
       source = "cloudflare/cloudflare"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4164

This PR bumps Terraform to 1.9.x and shared tools to their latest version