### PR TITLE
chore: separate updatecli to its own pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,27 +1,20 @@
-parallel(
-  failFast: false,
-  'terraform': {
-    terraform(
-      // TODO: create an empty account for staging
-      // "Read only" token
-      stagingCredentials: [
-        string(variable: 'TF_VAR_cloudflare_api_token', credentialsId:'staging-cloudflare-api-token'),
-        string(variable: 'TF_VAR_cloudflare_datadog_api_key', credentialsId:'cloudflare-datadog-api-key'),
-        file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging-terraform-cloudflare-backend-config'),
-      ],
-      // "Read write" token
-      productionCredentials: [
-        string(variable: 'TF_VAR_cloudflare_api_token', credentialsId:'production-cloudflare-api-token'),
-        string(variable: 'TF_VAR_cloudflare_datadog_api_key', credentialsId:'cloudflare-datadog-api-key'),
-        file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-cloudflare-backend-config'),
-      ],
-      publishReports: ['jenkins-infra-data-reports/cloudflare.json'],
-    )
-  },
-  'updatecli': {
-    updatecli(action: 'diff')
-    if (env.BRANCH_IS_PRIMARY) {
-      updatecli(action: 'apply', cronTriggerExpression: '@daily')
-    }
-  },
+if (env.BRANCH_IS_PRIMARY) {
+    // Only trigger a daily check on the principal branch
+    properties([pipelineTriggers([cron('@daily')])])
+}
+
+terraform(
+  // "Read only" token
+  stagingCredentials: [
+    string(variable: 'TF_VAR_cloudflare_api_token', credentialsId:'staging-cloudflare-api-token'),
+    string(variable: 'TF_VAR_cloudflare_datadog_api_key', credentialsId:'cloudflare-datadog-api-key'),
+    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging-terraform-cloudflare-backend-config'),
+  ],
+  // "Read write" token
+  productionCredentials: [
+    string(variable: 'TF_VAR_cloudflare_api_token', credentialsId:'production-cloudflare-api-token'),
+    string(variable: 'TF_VAR_cloudflare_datadog_api_key', credentialsId:'cloudflare-datadog-api-key'),
+    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-cloudflare-backend-config'),
+  ],
+  publishReports: ['jenkins-infra-data-reports/cloudflare.json'],
 )

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,0 +1,7 @@
+updatecli(action: 'diff')
+
+if (env.BRANCH_IS_PRIMARY) {
+    // Only trigger a daily check on the principal branch
+    properties([pipelineTriggers([cron('@daily')])])
+    updatecli(action: 'apply')
+}

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,6 +1,7 @@
+---
 github:
-  user: "Jenkins Infra Bot (updatecli)"
-  email: "60776566+jenkins-infra-bot@users.noreply.github.com"
+  user: "jenkins-infra-updatecli"
+  email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"
   username: "jenkins-infra-bot"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -2,7 +2,6 @@
 github:
   user: "jenkins-infra-updatecli"
   email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"
-  username: "jenkins-infra-bot"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"
   owner: "jenkins-infra"


### PR DESCRIPTION
This PR separates updatecli to its own pipeline and uses https://github.com/apps/jenkins-infra-updatecli instead of https://github.com/jenkins-infra-bot in updatecli values.
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778