### PR TITLE
feat(updates.jenkins.io) import 'audit_logs to datadog' logpush resource

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -6,11 +6,13 @@ parallel(
       // "Read only" token
       stagingCredentials: [
         string(variable: 'TF_VAR_cloudflare_api_token', credentialsId:'staging-cloudflare-api-token'),
+        string(variable: 'TF_VAR_cloudflare_datadog_api_key', credentialsId:'cloudflare-datadog-api-key'),
         file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging-terraform-cloudflare-backend-config'),
       ],
       // "Read write" token
       productionCredentials: [
         string(variable: 'TF_VAR_cloudflare_api_token', credentialsId:'production-cloudflare-api-token'),
+        string(variable: 'TF_VAR_cloudflare_datadog_api_key', credentialsId:'cloudflare-datadog-api-key'),
         file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-cloudflare-backend-config'),
       ],
     )

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,3 @@
 provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
-
-variable "cloudflare_api_token" {}

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -18,3 +18,38 @@ output "zones_name_servers" {
     for k, zone in cloudflare_zone.updates_jenkins_io : k => zone.name_servers
   }
 }
+
+import {
+  id = "account/${local.account_id.jenkins-infra-team}/772143"
+  to = cloudflare_logpush_job.account_audit_logs
+}
+resource "cloudflare_logpush_job" "account_audit_logs" {
+  enabled          = true
+  account_id       = local.account_id.jenkins-infra-team
+  name             = "account-audit-logs-to-datadog"
+  destination_conf = "datadog://http-intake.logs.datadoghq.com/api/v2/logs?header_DD-API-KEY=${var.cloudflare_datadog_api_key}&ddsource=cloudflare&service=updates.jenkins.io&host=cloudflare.jenkins.io"
+  dataset          = "audit_logs"
+
+  output_options {
+    cve20214428      = true
+    sample_rate      = 0
+    timestamp_format = "rfc3339"
+    field_names = [
+      "ActionResult",
+      "ActionType",
+      "ActorEmail",
+      "ActorID",
+      "ActorIP",
+      "ActorType",
+      "ID",
+      "Interface",
+      "Metadata",
+      "NewValue",
+      "OldValue",
+      "OwnerID",
+      "ResourceID",
+      "ResourceType",
+      "When"
+    ]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,10 @@
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token to allow Terraform manipulating resources"
+  sensitive   = true
+}
+
+variable "cloudflare_datadog_api_key" {
+  description = "Datadog API key used by Cloudflare to push logs, metrics and traces"
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2449427160

This PR import the existing `logpush` created at the account level to push the audit logs to datadog.

It's a first step before:
- Importing the the `http_requests` logpush to datadog for eastamerica created manually by @smerle33 and I testing the new feature (required Cloudflare account to be set top "Enterprise")
-  Creating a `http_requests` logpush to datadog for westeurope (same settings)


⚠️ This PR needs the datadog API key to be set as a credential in the pipeline: keeping as draft until it's done 


Note: this PR also has 2 minor but needed changes:

- Updating shared tools to latest available version
- Setting the cloudflare API token input variable as sensitive...