### PR TITLE
 feat(updates.jenkins.io) import 'http_requests to datadog' logpush resource for eastamerica

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -53,3 +53,93 @@ resource "cloudflare_logpush_job" "account_audit_logs" {
     ]
   }
 }
+
+import {
+  id = "zone/${cloudflare_zone.updates_jenkins_io["eastamerica"].id}/771340"
+  to = cloudflare_logpush_job.zones_access_logs["eastamerica"]
+}
+resource "cloudflare_logpush_job" "zones_access_logs" {
+  for_each = toset(["eastamerica"])
+
+  enabled          = true
+  zone_id          = cloudflare_zone.updates_jenkins_io[each.key].id
+  name             = "${each.key}-access-logs-to-datadog"
+  destination_conf = "datadog://http-intake.logs.datadoghq.com/api/v2/logs?header_DD-API-KEY=${var.cloudflare_datadog_api_key}&ddsource=cloudflare-r2&service=updates.jenkins.io&host=${each.key}.cloudflare.jenkins.io"
+  dataset          = "http_requests"
+
+  output_options {
+    cve20214428      = true
+    sample_rate      = 0
+    timestamp_format = "rfc3339"
+    field_names = [
+      "RayID",
+      "CacheCacheStatus",
+      "CacheReserveUsed",
+      "CacheResponseBytes",
+      "CacheResponseStatus",
+      "CacheTieredFill",
+      "ClientASN",
+      "ClientCountry",
+      "ClientDeviceType",
+      "ClientIP",
+      "ClientIPClass",
+      "ClientRegionCode",
+      "ClientRequestBytes",
+      "ClientRequestHost",
+      "ClientRequestMethod",
+      "ClientRequestPath",
+      "ClientRequestProtocol",
+      "ClientRequestReferer",
+      "ClientRequestScheme",
+      "ClientRequestSource",
+      "ClientRequestURI",
+      "ClientRequestUserAgent",
+      "ClientSrcPort",
+      "ClientTCPRTTMs",
+      "ClientXRequestedWith",
+      "ContentScanObjResults",
+      "ContentScanObjTypes",
+      "Cookies",
+      "EdgeEndTimestamp",
+      "EdgePathingOp",
+      "EdgePathingSrc",
+      "EdgePathingStatus",
+      "EdgeRequestHost",
+      "EdgeResponseBodyBytes",
+      "EdgeResponseBytes",
+      "EdgeResponseCompressionRatio",
+      "EdgeResponseContentType",
+      "EdgeResponseStatus",
+      "EdgeStartTimestamp",
+      "EdgeTimeToFirstByteMs",
+      "OriginDNSResponseTimeMs",
+      "OriginIP",
+      "OriginRequestHeaderSendDurationMs",
+      "OriginResponseBytes",
+      "OriginResponseDurationMs",
+      "OriginResponseHeaderReceiveDurationMs",
+      "OriginResponseHTTPExpires",
+      "OriginResponseHTTPLastModified",
+      "OriginResponseStatus",
+      "OriginResponseTime",
+      "OriginTCPHandshakeDurationMs",
+      "OriginTLSHandshakeDurationMs",
+      "RequestHeaders",
+      "ResponseHeaders",
+      "SecurityAction",
+      "SecurityActions",
+      "SecurityRuleDescription",
+      "SecurityRuleID",
+      "SecurityRuleIDs",
+      "SecuritySources",
+      "WAFAttackScore",
+      "WAFFlags",
+      "WAFMatchedVar",
+      "WAFRCEAttackScore",
+      "WAFSQLiAttackScore",
+      "WAFXSSAttackScore",
+      "WorkerCPUTime",
+      "WorkerWallTimeUs",
+    ]
+  }
+}


### PR DESCRIPTION
Follow up of #40 

Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2449427160

This PR imports the `logpush` resource which was created manually by @smerle33 and I to verify it works as expected, since Cloudflare upgraded our zones to "Enterprise" to enable the "per zone" analytics.


Notes:

- Updatecli check fails: gotta check this on a separate PR
- The main build will fail on the staging part due to the `import` block, as `terraform-staging` is not allowed to check resources managed by `terraform-production`