### PR TITLE
chore(outputs): export output to jenkins infra reports

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -15,6 +15,7 @@ parallel(
         string(variable: 'TF_VAR_cloudflare_datadog_api_key', credentialsId:'cloudflare-datadog-api-key'),
         file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-cloudflare-backend-config'),
       ],
+      publishReports: ['jenkins-infra-data-reports/cloudflare.json'],
     )
   },
   'updatecli': {

--- a/outpufs.tf
+++ b/outpufs.tf
@@ -1,5 +1,0 @@
-output "zones_name_servers" {
-  value = {
-    for k, zone in cloudflare_zone.updates_jenkins_io : k => zone.name_servers
-  }
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,12 @@
+output "zones_name_servers" {
+  value = {
+    for k, zone in cloudflare_zone.updates_jenkins_io : k => zone.name_servers
+  }
+}
+
+resource "local_file" "jenkins_infra_data_report" {
+  content = jsonencode({
+    for k, zone in cloudflare_zone.updates_jenkins_io : "${k}.cloudflare.jenkins.io" => { "zone_nameservers" = zone.name_servers }
+  })
+  filename = "${path.module}/jenkins-infra-data-reports/cloudflare.json"
+}


### PR DESCRIPTION
export nameservers to reports : 
```
resource "local_file" "jenkins_infra_data_report" {
      + content              = jsonencode(
            {
              + "eastamerica.cloudflare.jenkins.io" = {
                  + zone_nameservers = [
                      + "jaxson.ns.cloudflare.com",
                      + "mira.ns.cloudflare.com",
                    ]
                }
              + "westeurope.cloudflare.jenkins.io"  = {
                  + zone_nameservers = [
                      + "jaxson.ns.cloudflare.com",
                      + "mira.ns.cloudflare.com",
                    ]
                }
            }
        )
```