### PR TITLE
feat(updates.jenkins.io) manage R2 tokens to access buckets

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -7,4 +7,24 @@ locals {
     westeurope  = "WEUR"
     eastamerica = "ENAM"
   }
+
+  r2_token_expiration_date = "2025-06-17T00:00:00Z"
+
+  r2_api_permissions = {
+    for x in data.cloudflare_account_api_token_permission_groups_list.this.result :
+    x.name => x.id
+    if contains(["Workers R2 Storage Bucket Item Read", "Workers R2 Storage Bucket Item Write"], x.name)
+  }
+
+  r2_allowed_ips = {
+    "trusted.jenkins.io" = [
+      "104.209.128.236/32", # Outbound IP of the trusted virtual network NAT gateway
+    ],
+    # Trusted agents outbound IPs retrievable in https://github.com/jenkins-infra/azure-net/blob/7aa7fc5a8a39dd7bafee0e89c4fffe096692baa8/outputs.tf#L11-L13
+    "trusted.sponsorship.jenkins.io" = [
+      "172.177.128.34/32",
+      "172.210.175.108/32",
+      "172.210.170.228/32",
+    ],
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,3 +10,14 @@ resource "local_file" "jenkins_infra_data_report" {
   })
   filename = "${path.module}/jenkins-infra-data-reports/cloudflare.json"
 }
+
+output "r2_buckets" {
+  sensitive = true
+  value = jsonencode({
+    for id, bucket in cloudflare_r2_bucket.updates_jenkins_io : id => {
+      "access_key_id"     = cloudflare_account_token.r2_updates_jenkins_io[id].id,
+      "secret_access_key" = sha256(cloudflare_account_token.r2_updates_jenkins_io[id].value),
+      "r2_endpoint_url"   = "https://${local.account_id["jenkins-infra-team"]}.r2.cloudflarestorage.com"
+    }
+  })
+}


### PR DESCRIPTION
Following https://github.com/jenkins-infra/helpdesk/issues/4601#issuecomment-2924535922, this PR adds the management of R2 tokens to this public repository, along with a sensitive output to be consumed by the trusted.ci script.