### PR TITLE
chore(backends) use clear-text backend config with only the `ARM_CLIENT_SECRET` as credential

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -34,8 +34,6 @@ override.tf.json
 terraform.rc
 
 # Jenkins-infra related files to ignore
-backend-config
 terraform-plan-output.txt
 tfplan
-.grit
 jenkins-infra-data-reports

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -3,12 +3,12 @@ terraform(
   stagingCredentials: [
     string(variable: 'TF_VAR_cloudflare_api_token', credentialsId:'staging-cloudflare-api-token'),
     string(variable: 'TF_VAR_cloudflare_datadog_api_key', credentialsId:'cloudflare-datadog-api-key'),
-    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging-terraform-cloudflare-backend-config'),
+    string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'staging-terraform-cloudflare-backend-config-arm-secret'),
   ],
   productionCredentials: [
     string(variable: 'TF_VAR_cloudflare_api_token', credentialsId:'production-cloudflare-api-token'),
     string(variable: 'TF_VAR_cloudflare_datadog_api_key', credentialsId:'cloudflare-datadog-api-key'),
-    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-cloudflare-backend-config'),
+    string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'production-terraform-cloudflare-backend-config-arm-secret'),
   ],
   publishReports: ['jenkins-infra-data-reports/cloudflare.json'],
 )

--- a/README.adoc
+++ b/README.adoc
@@ -10,17 +10,37 @@ This repository hosts the infrastructure-as-code definition for all the link:htt
 == Requirements
 
 * A CloudFlare account with an API token defined as the value of the environment variable `TF_VAR_cloudflare_api_token`
-* The requirements (of the shared tools) listed at link:{shared_tools_repo_url}/tree/main/terraform#requirements[{shared_tools_repo_name}/terraform#requirements]
-* The link:https://www.terraform.io/language/settings/backends/azurerm[Terraform AzureRM Backend Configuration] on a local file named `backend-config`:
-** The content can be retrieved from the outputs of the link:{private_repo_url}[(private) repository {private_repo_name}] or from the credentials of infra.ci.jenkins.io. 
-** This file (`backend-config`) is git-ignored
-
-* The git command line to allow cloning the repository and its submodule link:{shared_tools_repo_url}[{shared_tools_repo_name}]
-** This repository has link:https://git-scm.com/docs/git-submodule[submodules]. Once you cloned the repository, execute the following command to retrieve the shared tools:
+* The requirements (of the shared tools) listed at link:https://github.com/jenkins-infra/shared-tools/tree/main/terraform#requirements[shared-tools/terraform#requirements]
+* The link:https://github.com/jenkins-infra/shared-tools[shared-tools] common repository as a git submodule should be initialized and up-to-date:
+** On a freshly cloned Terraform repository, execute the following command to obtain the shared tools:
 
 [source,bash]
 ----
 git submodule update --init --recursive
+----
+
+** Otherwise you should update to to the latest `main` branch:
+
+[source,bash]
+----
+cd ./.shared-tools
+git pull origin main
+cd ../
+----
+
+* The Azure Credential Secret value to allow the Terraform AzureRM Backend to access remote Azure storage:
+** Must be specified in the environment variable `TF_BACKEND_ARM_CLIENT_SECRET`
+** The secret value should never be written in clear (not in a text file, not in the terminal). For instance on macOS, store it in your Keychain access and set the variable with `export TF_BACKEND_ARM_CLIENT_SECRET="$(security find-generic-password -a jenkins-tf-cloudflare-backend-arm-secret -w)"`
+
+* Routing to database (private endpoints and private DNSes):
+** VPN access is required with routing to the database subnets set up to your user
+** As there are no public DNS, set up your local `/etc/hosts` (check the `providers.tf` for details)
+
+* If you intend to work with the production, the environment variable `TF_VAR_environment` must be set:
+
+[source,bash]
+----
+export TF_VAR_environment=production
 ----
 
 == HowTo

--- a/backend-configs/production
+++ b/backend-configs/production
@@ -1,0 +1,5 @@
+resource_group_name  = "tf-remote-state-cloudflare-production-A7EX1o"
+storage_account_name = "cloudflareproducta7ex1o"
+container_name       = "cloudflareproducta7ex1o"
+client_id            = "193f845c-88cb-482c-98e5-347aee6a4fa6"
+# client_secret      = "" # Specified through the env. variable $TF_BACKEND_ARM_CLIENT_SECRET

--- a/backend-configs/staging
+++ b/backend-configs/staging
@@ -1,0 +1,5 @@
+resource_group_name  = "tf-remote-state-cloudflare-staging-sx4uXK"
+storage_account_name = "cloudflarestagingsx4uxk"
+container_name       = "cloudflarestagingsx4uxk"
+client_id            = "64d194ea-af01-487d-91bc-31c70556565f"
+# client_secret      = "" # Specified through the env. variable $TF_BACKEND_ARM_CLIENT_SECRET

--- a/backend.tf
+++ b/backend.tf
@@ -1,3 +1,7 @@
 terraform {
-  backend "azurerm" {}
+  backend "azurerm" {
+    subscription_id = "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+    tenant_id       = "4c45fef2-1ba7-4120-80a0-9e2d03e9c2b6"
+    key             = "terraform.tfstate"
+  }
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5169#issuecomment-4622327077